### PR TITLE
Updated Dockerfile with latest version and correct app name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7-slim
 
-ENV APP_VERSION="4.0.0" \
-    APP="platformio-core"
+ENV APP_VERSION="4.3.1" \
+    APP="platformio"
 
 LABEL app.name="${APP}" \
       app.version="${APP_VERSION}" \


### PR DESCRIPTION
The latest stable version of platformio is now 4.3.1 and the correct app name for pip install is `platformio`, not `platformio-core`.