### PR TITLE
Tweaks for the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9.0-slim
 
-ENV APP_VERSION="5.1.0" \
+ENV APP_VERSION="5.1.1" \
     APP="platformio-core"
 
 LABEL app.name="${APP}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ LABEL app.name="${APP}" \
       maintainer="Sebastian Glahn <hi@sgla.hn>"
 
 RUN pip install -U platformio==${APP_VERSION} && \
-    mkdir -p /workspace && \
     mkdir -p /.platformio && \
     chmod a+rwx /.platformio && \
     apt update && apt install -y git && apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/{apt,dpkg,cache,log}/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL app.name="${APP}" \
 RUN pip install -U platformio==${APP_VERSION} && \
     mkdir -p /.platformio && \
     chmod a+rwx /.platformio && \
-    apt update && apt install -y git && apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/{apt,dpkg,cache,log}/
+    apt-get update && apt-get install -y git && apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 USER 1001
 


### PR DESCRIPTION
* No need to create a workspace yourself, `WORKDIR` will do it for you.
* `"WARNING: apt does not have a stable CLI interface. Use with caution in scripts."`
* PlatformIO to Version 5.1.1

