### PR TITLE
added dialout group to allow USB access

### DIFF
--- a/platformio
+++ b/platformio
@@ -22,7 +22,7 @@ fi
 docker run --rm \
     -v `pwd`:/workspace \
     --volumes-from=$VOLUME_CONTAINER_NAME \
-    -u `id -u $USER`:`id -g $USER` \
+    -u `id -u $USER`:`id -g $USER` --group-add=dialout \
     $DEVICE \
     $IMAGE_NAME \
     $@


### PR DESCRIPTION
w/o that an upload will fail with _Permission denied_

<details>

```
Configuring upload protocol...
AVAILABLE: espota, esptool
CURRENT: upload_protocol = esptool
Looking for upload port...

Warning! Please install `99-platformio-udev.rules`. 
More details: https://docs.platformio.org/page/faq.html#platformio-udev-rules

Auto-detected: /dev/ttyUSB0
Uploading .pio/build/nodemcuv2-ble/firmware.bin
esptool.py v3.0
Traceback (most recent call last):
Serial port /dev/ttyUSB0
  File "/usr/local/lib/python3.9/site-packages/serial/serialposix.py", line 322, in open
    self.fd = os.open(self.portstr, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
PermissionError: [Errno 13] Permission denied: '/dev/ttyUSB0'
```
</details>